### PR TITLE
Migrate HaveIBeenPwned to v3 API.

### DIFF
--- a/Apps/phhaveibeenpwned/haveibeenpwned.json
+++ b/Apps/phhaveibeenpwned/haveibeenpwned.json
@@ -10,7 +10,7 @@
   "product_name": "Have I Been Pwned",
   "product_version_regex": ".*",
   "logo": "haveibeenpwned.png",
-  "min_phantom_version": "2.0.264",
+  "min_phantom_version": "4.2.7532",
   "publisher": "Phantom",
   "package_name": "phantom_haveibeenpwned",
   "license": "Copyright (c) Splunk 2016-2019",

--- a/Apps/phhaveibeenpwned/haveibeenpwned_connector.py
+++ b/Apps/phhaveibeenpwned/haveibeenpwned_connector.py
@@ -1,11 +1,7 @@
-# --
 # File: haveibeenpwned_connector.py
-#
-# Copyright (c) Phantom Cyber Corporation, 2016-2019
+# Copyright (c) 2019 Splunk Inc.
 #
 # Licensed under Apache 2.0 (https://www.apache.org/licenses/LICENSE-2.0.txt)
-#
-# --
 
 # Phantom imports
 import phantom.app as phantom

--- a/Apps/phhaveibeenpwned/haveibeenpwned_consts.py
+++ b/Apps/phhaveibeenpwned/haveibeenpwned_consts.py
@@ -1,11 +1,7 @@
-# --
 # File: haveibeenpwned_consts.py
-#
-# Copyright (c) Phantom Cyber Corporation, 2016-2019
+# Copyright (c) 2019 Splunk Inc.
 #
 # Licensed under Apache 2.0 (https://www.apache.org/licenses/LICENSE-2.0.txt)
-#
-# --
 
 HAVEIBEENPWNED_API_BASE_URL = "https://haveibeenpwned.com/api/v3/"
 HAVEIBEENPWNED_API_ENDPOINT_LOOKUP_EMAIL = "breachedaccount/{email}"


### PR DESCRIPTION
#74 version 2.0 api was deprecated and now, one must:

1. use the v3 API endpoints
2. pay for a key

Basic fidelity has been re-implemented in this version