### PR TITLE
add email to HIBP lookup email output table

### DIFF
--- a/Apps/phhaveibeenpwned/haveibeenpwned.json
+++ b/Apps/phhaveibeenpwned/haveibeenpwned.json
@@ -48,8 +48,7 @@
             "True",
             "False"
           ],
-          "default": "True",
-          "required": true
+          "default": "False"
         }
       },
       "render": {
@@ -63,7 +62,7 @@
           "data_path": "action_result.data.*.Name",
           "data_type": "string",
           "column_name": "Company",
-          "column_order": 0
+          "column_order": 1
         },
         {
           "data_path": "action_result.data.*.Title",
@@ -76,7 +75,7 @@
             "domain"
           ],
           "column_name": "Domain",
-          "column_order": 1
+          "column_order": 2
         },
         {
           "data_path": "action_result.data.*.IsActive",
@@ -102,7 +101,7 @@
           "data_path": "action_result.data.*.BreachDate",
           "data_type": "string",
           "column_name": "Date Of Breach",
-          "column_order": 2
+          "column_order": 3
         },
         {
           "data_path": "action_result.data.*.IsSpamList",
@@ -111,13 +110,13 @@
         {
           "data_path": "action_result.data.*.IsVerified",
           "data_type": "boolean",
-          "column_order": 3,
+          "column_order": 4,
           "column_name": "Verified"
         },
         {
           "data_path": "action_result.data.*.DataClasses",
           "data_type": "string",
-          "column_order": 4,
+          "column_order": 5,
           "column_name": "Data Compromised"
         },
         {
@@ -141,7 +140,9 @@
           "data_type": "string",
           "contains": [
             "email"
-          ]
+          ],
+          "column_order": 0,
+          "column_name": "Email"
         },
         {
           "data_path": "action_result.summary",


### PR DESCRIPTION
When running multiple emails at once, it helps to quickly see which emails had hits.