### PR TITLE
Added option to ignore parsing errors. Github issue 138

### DIFF
--- a/Apps/phrss/rss.json
+++ b/Apps/phrss/rss.json
@@ -35,32 +35,32 @@
             "required": true,
             "order": 0
         },
-        "ignore_perrors": {
-            "description": "Ignore parsing errors",
-            "data_type": "boolean",
-            "required": false,
-            "default": false,
-            "order": 1
-        },
         "save_file": {
             "description": "Save file to vault",
             "data_type": "boolean",
             "required": false,
             "default": false,
-            "order": 2
+            "order": 1
         },
         "container_count": {
             "description": "Maximum entries to parse (0 for all)",
             "data_type": "numeric",
             "required": false,
             "default": 0,
-            "order": 3
+            "order": 2
         },
         "artifact_count": {
             "description": "Maximum artifacts to create per entry (0 for all)",
             "data_type": "numeric",
             "required": false,
             "default": 0,
+            "order": 3
+        },
+        "ignore_perrors": {
+            "description": "Ignore parsing errors",
+            "data_type": "boolean",
+            "required": false,
+            "default": false,
             "order": 4
         }
     },

--- a/Apps/phrss/rss.json
+++ b/Apps/phrss/rss.json
@@ -35,26 +35,33 @@
             "required": true,
             "order": 0
         },
+        "ignore_perrors": {
+            "description": "Ignore parsing errors",
+            "data_type": "boolean",
+            "required": false,
+            "default": false,
+            "order": 1
+        },
         "save_file": {
             "description": "Save file to vault",
             "data_type": "boolean",
             "required": false,
             "default": false,
-            "order": 1
+            "order": 2
         },
         "container_count": {
             "description": "Maximum entries to parse (0 for all)",
             "data_type": "numeric",
             "required": false,
             "default": 0,
-            "order": 2
+            "order": 3
         },
         "artifact_count": {
             "description": "Maximum artifacts to create per entry (0 for all)",
             "data_type": "numeric",
             "required": false,
             "default": 0,
-            "order": 3
+            "order": 4
         }
     },
     "actions": [

--- a/Apps/phrss/rss_connector.py
+++ b/Apps/phrss/rss_connector.py
@@ -36,8 +36,12 @@ class RssConnector(BaseConnector):
     def _init_feed(self):
         config = self.get_config()
         feed_url = config['rss_feed']
+        ignore_perrors = config.get('ignore_perrors', False)
         self._feed = feedparser.parse(feed_url)
         if self._feed.bozo == 1:
+            ex_type = type(self._feed.bozo_exception)
+            if ignore_perrors and ex_type is feedparser.CharacterEncodingOverride:
+               return phantom.APP_SUCCESS
             error_msg = self._feed.bozo_exception
             self.save_progress("Error reading feed: {}".format(error_msg))
             self.save_progress("Is this an RSS Feed?")


### PR DESCRIPTION
**For phrss app**

- Added a checkbox to set an option `ignore_perrors`
- Used the option to ignore `CharacterEncodingOverride` errors in the library FeedParser. Other errors will still cause a failure.