### PR TITLE
more secure cuckoo results link

### DIFF
--- a/Apps/phcuckoo/view_results.html
+++ b/Apps/phcuckoo/view_results.html
@@ -121,7 +121,7 @@
               {% if result.summary.results_url %}
               <div>
                 <b>Source Link:</b> &nbsp;
-                <a href="{{ result.summary.results_url }}" target="_blank">
+                <a href="{{ result.summary.results_url }}" target="_blank" rel="noopener noreferrer">
                   Task {{ item.id }}
                 </a>
               </div>


### PR DESCRIPTION
Set the link type of the cuckoo results link to "noopener noreferrer"
so the target page can no longer read the phantom page.