### PR TITLE
PAPP-9706 Radar: changing the app type

### DIFF
--- a/Apps/phradar/radar.json
+++ b/Apps/phradar/radar.json
@@ -2,7 +2,7 @@
   "appid": "f8fbcb9f-fc58-438c-9e39-14f034279b29",
   "name": "Radar",
   "description": "This app integrates with the Radar incident response platform",
-  "type": "privacy incident response",
+  "type": "devops",
   "product_vendor": "RADAR, LLC",
   "url": "https://www.radarfirst.com/radar",
   "logo": "logo_radar.svg",


### PR DESCRIPTION
As discussed with @brian-phantom, changing the _app_type_ in the app JSON