### PR TITLE
Fixes #309: Bug in phtaniumrest app when multiple sensors and one or more has a parameter

### DIFF
--- a/Apps/phtaniumrest/taniumrest_connector.py
+++ b/Apps/phtaniumrest/taniumrest_connector.py
@@ -361,7 +361,7 @@ class TaniumRestConnector(BaseConnector):
             action_result.set_status(phantom.APP_ERROR, "Unexpected API response")
             return None
 
-    def _execute_action_support(self, param, action_result):
+    def _execute_action_support(self, param, action_result): # noqa: 901
         action_grp = self._handle_py_ver_compat_for_input_str(self._python_version, param['action_group'])
         package_name = self._handle_py_ver_compat_for_input_str(self._python_version, param['package_name'])
         action_name = param['action_name']

--- a/Apps/phtaniumrest/taniumrest_connector.py
+++ b/Apps/phtaniumrest/taniumrest_connector.py
@@ -798,7 +798,11 @@ class TaniumRestConnector(BaseConnector):
                 return
 
             self.save_progress("Parameter Definition:\n" + resp_data.get("parameter_definition", ""))
-            parameter_definition = json.loads(resp_data.get("parameter_definition", ""))
+
+            raw_parameter_definition = resp_data.get("parameter_definition", "")
+            parameter_definition = None
+            if raw_parameter_definition != "":
+                parameter_definition = json.loads(raw_parameter_definition)
 
             if parameter_definition:
                 # Parameterized Sensor


### PR DESCRIPTION
This PR fixes #309. The change adds an extra check to ensure that `json.loads` is not called on an empty string (which is what is causing the failure in #309).