### PR TITLE
phtaniumrest Feature Implementation RE: Issue 187

### DIFF
--- a/Apps/phtaniumrest/taniumrest.json
+++ b/Apps/phtaniumrest/taniumrest.json
@@ -14,7 +14,7 @@
     "latest_tested_versions": [
         "Build (Windows): 7.3.314.4269 | Console: 1.3.3.0150"
     ],
-    "app_version": "2.0.0",
+    "app_version": "2.0.0-187",
     "utctime_updated": "2020-04-17T09:06:28.000000Z",
     "package_name": "phantom_taniumrest",
     "main_module": "taniumrest_connector.py",
@@ -431,6 +431,16 @@
                     "data_type": "numeric",
                     "example_values": [
                         0
+                    ]
+                },
+                {
+                    "data_path": "action_result.data.*.group",
+                    "data_type": "string",
+                    "example_values": [
+                        "{ group id object }"
+                    ],
+                    "contains": [
+                        "taniumrest group definition"
                     ]
                 },
                 {
@@ -1395,7 +1405,11 @@
                 "group_name": {
                     "description": "The Tanium Computer Group name on which the action will be executed. If left blank, will execute on all registered IP addresses/hostnames in your Tanium instance",
                     "data_type": "string",
-                    "order": 4
+                    "order": 4,
+                    "contains": [
+                        "taniumrest group definition",
+                        "string"
+                     ]
                 },
                 "distribute_seconds": {
                     "description": "The number of seconds over which to deploy the action",

--- a/Apps/phtaniumrest/taniumrest_connector.py
+++ b/Apps/phtaniumrest/taniumrest_connector.py
@@ -361,7 +361,7 @@ class TaniumRestConnector(BaseConnector):
             action_result.set_status(phantom.APP_ERROR, "Unexpected API response")
             return None
 
-    def _execute_action_support(self, param, action_result):
+    def _execute_action_support(self, param, action_result): # noqa: 901
         action_grp = self._handle_py_ver_compat_for_input_str(self._python_version, param['action_group'])
         package_name = self._handle_py_ver_compat_for_input_str(self._python_version, param['package_name'])
         action_name = param['action_name']


### PR DESCRIPTION
This PR implements the feature requested in Issues #187.

This PR mirrors the REST API semantics for specifying a group of endpoints that are not already a pre-defined (named) group in Tanium. 

The changes enable the engineer to construct a `parse question` that identifies all the workstation in the group, and then pipe the output of that `parse question` action (`parse_question_1:action_result.data.*.group`) into the `group_name` parameter for the `execute action` action. 

Here's an example python playbook that exercises the new feature:

<img width="695" alt="187" src="https://user-images.githubusercontent.com/1719280/91366694-afa8c880-e7c1-11ea-8a12-79fac619a339.png">


```python

import phantom.rules as phantom
import json
from datetime import datetime, timedelta
def on_start(container):
    phantom.debug('on_start() called')
    
    # call 'parse_question_1' block
    parse_question_1(container=container)

    return

def parse_question_1(action=None, success=None, container=None, results=None, handle=None, filtered_artifacts=None, filtered_results=None):
    phantom.debug('parse_question_1() called')

    # collect data for 'parse_question_1' call

    parameters = []
    
    # build parameters list for 'parse_question_1' call
    parameters.append({
        'query_text': "Get Computer Name from all machines with Computer Name contains lab",
    })

    phantom.act("parse question", parameters=parameters, assets=['tanium'], callback=execute_action_1, name="parse_question_1")

    return

def execute_action_1(action=None, success=None, container=None, results=None, handle=None, filtered_artifacts=None, filtered_results=None):
    phantom.debug('execute_action_1() called')
    
    #phantom.debug('Action: {0} {1}'.format(action['name'], ('SUCCEEDED' if success else 'FAILED')))
    
    # collect data for 'execute_action_1' call
    results_data_1 = phantom.collect2(container=container, datapath=['parse_question_1:action_result.data.*.group', 'parse_question_1:action_result.parameter.context.artifact_id'], action_results=results)

    parameters = []
    
    # build parameters list for 'execute_action_1' call
    for results_item_1 in results_data_1:
        parameters.append({
            'action_name': "Run Action for 187",
            'action_group': "Default",
            'package_name': "Tanium Action Name Here",
            'package_parameters': "",
            'group_name': results_item_1[0],
            'distribute_seconds': "",
            'issue_seconds': "",
            'expire_seconds': 600,
            # context (artifact id) is added to associate results with the artifact
            'context': {'artifact_id': results_item_1[1]},
        })

    phantom.act("execute action", parameters=parameters, assets=['tanium'], callback=print_results, name="execute_action_1", parent_action=action)

    return

def print_results(action=None, success=None, container=None, results=None, handle=None, filtered_artifacts=None, filtered_results=None):
    phantom.debug('print_results() called')
    results_data_1 = phantom.collect2(container=container, datapath=['execute_action_1:action_result.data'], action_results=results)
    results_item_1_0 = [item[0] for item in results_data_1]

    ################################################################################
    ## Custom Code Start
    ################################################################################

    phantom.debug(results_item_1_0)

    ################################################################################
    ## Custom Code End
    ################################################################################

    return

def on_finish(container, summary):
    phantom.debug('on_finish() called')
    # This function is called after all actions are completed.
    # summary of all the action and/or all detals of actions
    # can be collected here.

    # summary_json = phantom.get_summary()
    # if 'result' in summary_json:
        # for action_result in summary_json['result']:
            # if 'action_run_id' in action_result:
                # action_results = phantom.get_action_results(action_run_id=action_result['action_run_id'], result_data=False, flatten=False)
                # phantom.debug(action_results)

    return
```
