### PR TITLE
Cofense Triage: Bug fix for Github issue #333

### DIFF
--- a/Apps/phcofensetriage/cofensetriage_connector.py
+++ b/Apps/phcofensetriage/cofensetriage_connector.py
@@ -716,7 +716,9 @@ class CofenseTriageConnector(BaseConnector):
             if page_dir != "1st_page first":
                 desired_pages = reversed(desired_pages)
 
-            ratelimit = int(self._r.headers['X-RateLimit-Remaining'])
+            # Fallback to a default rate limit if the Cofense Triage API does
+            # not respond with the X-RateLimit-Remaining header.
+            ratelimit = int(self._r.headers.get('X-RateLimit-Remaining', DEFAULT_COFENSE_TRIAGE_RATE_LIMIT))
 
             for page in desired_pages:
 
@@ -747,7 +749,7 @@ class CofenseTriageConnector(BaseConnector):
                 downloaded_results += response
                 downloaded_length = len(downloaded_results)
 
-                ratelimit = int(self._r.headers['X-RateLimit-Remaining'])
+                ratelimit = int(self._r.headers.get('X-RateLimit-Remaining', DEFAULT_COFENSE_TRIAGE_RATE_LIMIT))
 
                 self.save_progress("Retrieved page {} with {} results. Retrieved {} of {} total results. {} limit of {} max results".format(
                     params['page'], len(response), downloaded_length, total_results, "Reached" if downloaded_length >= max_results else "Not at", max_results))

--- a/Apps/phcofensetriage/cofensetriage_consts.py
+++ b/Apps/phcofensetriage/cofensetriage_consts.py
@@ -13,6 +13,13 @@ PHANTOM_VAULT_DIR = "/opt/phantom/vault/tmp/"
 #
 MAX_PER_PAGE = 50
 DEFAULT_MAX_DOWNLOADED_RESULTS = 150
+
+# By default, client applications can make 25 requests to Cofense Triage within
+# a five-minute interval using the Cofense Triage API.
+#
+# This constant is used as a default value when the Cofense Triage API does not
+# explicitly respond with the X-RateLimit-Remaining header.
+DEFAULT_COFENSE_TRIAGE_RATE_LIMIT = 25
 #
 ENDPOINT_TYPE_VALUES = {
     "/reports": [ "all", "reports", "all reports"],


### PR DESCRIPTION
This pull request fixes the KeyError exception encountered when the Cofense Triage API does not respond with the X-RateLimit-Remaining header that the app expects. A default value of 25 is used in that case.

Fixes issue #333.