### PR TITLE
Mimecast: Version update due to Python3 compatibility

### DIFF
--- a/Apps/phmimecast/mimecast.json
+++ b/Apps/phmimecast/mimecast.json
@@ -10,7 +10,7 @@
     "product_version_regex": ".*",
     "publisher": "Splunk",
     "license": "Copyright (c) 2019-2020 Splunk Inc.",
-    "app_version": "1.0.10",
+    "app_version": "2.0.0",
     "python_version": "3",
     "utctime_updated": "2020-10-22T09:06:48.000000Z",
     "package_name": "phantom_mimecast",


### PR DESCRIPTION
We've performed the Python 3 conversion, hence upgrading the version from 1.0.9 to 2.0.0