### PR TITLE
Add thread support to 'send message' action

### DIFF
--- a/Apps/phslack/slack.json
+++ b/Apps/phslack/slack.json
@@ -1280,6 +1280,21 @@
                     "data_type": "string",
                     "required": true,
                     "order": 1
+                },
+                "parent_message_ts": {
+                    "description": "Parent message ts to reply in thread",
+                    "data_type": "string",
+                    "required": false,
+                    "order": 2,
+                    "contains": [
+                        "slack thread ts"
+                    ]
+                },
+                "reply_broadcast": {
+                    "description": "If posting in a thread, also broadcast to channel",
+                    "data_type": "boolean",
+                    "required": false,
+                    "order": 3
                 }
             },
             "render": {
@@ -1332,7 +1347,10 @@
                 },
                 {
                     "data_path": "action_result.data.*.message.ts",
-                    "data_type": "string"
+                    "data_type": "string",
+                    "contains": [
+                        "slack thread ts"
+                    ]
                 },
                 {
                     "data_path": "action_result.data.*.message.type",

--- a/Apps/phslack/slack_connector.py
+++ b/Apps/phslack/slack_connector.py
@@ -702,7 +702,14 @@ class SlackConnector(phantom.BaseConnector):
         if len(message) > consts.SLACK_MESSAGE_LIMIT:
             return (action_result.set_status(phantom.APP_ERROR, "Message too long. Please limit messages to {0} characters.".format(consts.SLACK_MESSAGE_LIMIT)))
 
-        params = {'channel': param['destination'], 'text': message, 'as_user': True}
+        params = {'channel': param['destination'], 'text': message}
+
+        if 'parent_message_ts' in param:
+            # Support for replying in thread
+            params['thread_ts'] = param['parent_message_ts']
+
+            if 'reply_broadcast' in param:
+                params['reply_broadcast'] = param['reply_broadcast']
 
         ret_val, resp_json = self._make_slack_rest_call(action_result, consts.SLACK_SEND_MESSAGE, params)
 


### PR DESCRIPTION
Add optional parameters to the send message action, and supporting code, to allow messages to be sent as thread replies.