### PR TITLE
Don't request creating an issue for pull requests

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -34,9 +34,8 @@ If you are not familiar with a fork-and-branch Git workflow, or just feel a bit 
 ## Contributing Bug-fixes
 If you've found a bug and wish to fix it, the first thing to do is
 
-1. If one does not already exist, create an Issue (otherwise we'll use the existing one)
 1. [Fork](https://guides.github.com/activities/forking/) the project
-1. Create a branch for the issue
+1. Create a branch
 1. Make your changes on your branch
 1. Thoroughly test your changes. See the [Automated Checks](#automated-checks) section for information about basic automated checks we provide for all apps.
 1. Add your name to the contributors list in the app JSON! [Example](https://github.com/phantomcyber/phantom-apps/pull/488/commits/a02e345ce48e56bcb8711d1c5c4e40dd6e62fd11?diff=split&w=1)
@@ -56,9 +55,8 @@ If you've found a bug and wish to fix it, the first thing to do is
 
 If you've created a brand new App and wish to contribute it, the steps to do so are as follows.
 
-1. If one does not already exist, create an Issue (otherwise we'll use the existing one)
 1. [Fork](https://guides.github.com/activities/forking/) the project
-1. Create a branch for the issue (following our [Conventions](https://github.com/phantomcyber/phantom-apps/blob/next/.github/CONVENTIONS.md)))
+1. Create a branch (following our [Conventions](https://github.com/phantomcyber/phantom-apps/blob/next/.github/CONVENTIONS.md)))
 1. Create a new directory/folder for your App (again following the [Conventions](https://github.com/phantomcyber/phantom-apps/blob/next/.github/CONVENTIONS.md)).
 1. Add your app code to the folder. Ensure no other folders are affected.
 1. **Thoroughly** test your code for the new App. See the [Automated Checks](#automated-checks) section for information about basic automated checks we provide for all apps.


### PR DESCRIPTION
The contribution guide currently asks people to create an issue before opening a pull request. However, this approach results in duplicated information and obscuring visibility into actual issues (e.g. bug submissions with no associated pull request).