### PR TITLE
Fixed 'run_automation'=True being dropped

### DIFF
--- a/Apps/phcrowdstrikeoauth/crowdstrikeoauthapi.json
+++ b/Apps/phcrowdstrikeoauth/crowdstrikeoauthapi.json
@@ -9,6 +9,11 @@
     "product_name": "CrowdStrike",
     "product_version_regex": ".*",
     "publisher": "Splunk",
+    "contributors": [
+        {
+          "name": "Harrison Smith"
+        }
+      ],
     "license": "Copyright (c) 2019-2021 Splunk Inc.",
     "app_version": "2.0.6",
     "latest_tested_versions": [

--- a/Apps/phcrowdstrikeoauth/crowdstrikeoauthapi_connector.py
+++ b/Apps/phcrowdstrikeoauth/crowdstrikeoauthapi_connector.py
@@ -323,7 +323,6 @@ class CrowdstrikeConnector(BaseConnector):
 
             # get the length of the artifact, we might have trimmed it or not
             len_artifacts = len(artifacts)
-            
             # Always set the very first artifact to run_automation = True to never have duplicate conflicts
             if len_artifacts >= 1:
                 artifacts[0]['run_automation'] = True

--- a/Apps/phcrowdstrikeoauth/crowdstrikeoauthapi_connector.py
+++ b/Apps/phcrowdstrikeoauth/crowdstrikeoauthapi_connector.py
@@ -1780,7 +1780,7 @@ class CrowdstrikeConnector(BaseConnector):
 
         return parameter
 
-    def _on_poll(self, param):
+    def _on_poll(self, param): # noqa: C901
 
         self.save_progress("In action handler for: {0}".format(self.get_action_identifier()))
         action_result = self.add_action_result(ActionResult(dict(param)))

--- a/Apps/phcrowdstrikeoauth/crowdstrikeoauthapi_connector.py
+++ b/Apps/phcrowdstrikeoauth/crowdstrikeoauthapi_connector.py
@@ -323,13 +323,11 @@ class CrowdstrikeConnector(BaseConnector):
 
             # get the length of the artifact, we might have trimmed it or not
             len_artifacts = len(artifacts)
-            # if there is only a single artifact, set it to run_automation = True
-            if len_artifacts == 1:
+            
+            # Always set the very first artifact to run_automation = True to never have duplicate conflicts
+            if len_artifacts >= 1:
                 artifacts[0]['run_automation'] = True
-            # if there are more than 1 artifacts, set the second artifact to run_automation = True
-            elif len_artifacts > 1:
-                artifacts[1]['run_automation'] = True
-            # append container ID to each artifact for logging
+            # Useful for spawn.log file analysis
             for artifact in artifacts:
                 artifact['container_id'] = container_id
 

--- a/Apps/phcrowdstrikeoauth/crowdstrikeoauthapi_connector.py
+++ b/Apps/phcrowdstrikeoauth/crowdstrikeoauthapi_connector.py
@@ -323,13 +323,15 @@ class CrowdstrikeConnector(BaseConnector):
 
             # get the length of the artifact, we might have trimmed it or not
             len_artifacts = len(artifacts)
-            for j, artifact in enumerate(artifacts):
-
-                # if it is the last artifact of the last container
-                if (j + 1) == len_artifacts:
-                    # mark it such that active playbooks get executed
-                    artifact['run_automation'] = True
-
+            
+            # if there is only a single artifact, set it to run_automation = True 
+            if len_artifacts == 1:
+                artifacts[0]['run_automation'] = True
+            # if there are more than 1 artifacts, set the second artifact to run_automation = True   
+            elif len_artifacts > 1:
+                artifacts[1]['run_automation'] = True
+            # append container ID to each artifact for logging    
+            for artifact in artifacts:
                 artifact['container_id'] = container_id
 
             ret_val, status_string, artifact_ids = self.save_artifacts(artifacts)

--- a/Apps/phcrowdstrikeoauth/crowdstrikeoauthapi_connector.py
+++ b/Apps/phcrowdstrikeoauth/crowdstrikeoauthapi_connector.py
@@ -323,14 +323,13 @@ class CrowdstrikeConnector(BaseConnector):
 
             # get the length of the artifact, we might have trimmed it or not
             len_artifacts = len(artifacts)
-            
-            # if there is only a single artifact, set it to run_automation = True 
+            # if there is only a single artifact, set it to run_automation = True
             if len_artifacts == 1:
                 artifacts[0]['run_automation'] = True
-            # if there are more than 1 artifacts, set the second artifact to run_automation = True   
+            # if there are more than 1 artifacts, set the second artifact to run_automation = True
             elif len_artifacts > 1:
                 artifacts[1]['run_automation'] = True
-            # append container ID to each artifact for logging    
+            # append container ID to each artifact for logging
             for artifact in artifacts:
                 artifact['container_id'] = container_id
 

--- a/Apps/phcrowdstrikeoauth/crowdstrikeoauthapi_connector.py
+++ b/Apps/phcrowdstrikeoauth/crowdstrikeoauthapi_connector.py
@@ -1780,7 +1780,7 @@ class CrowdstrikeConnector(BaseConnector):
 
         return parameter
 
-    def _on_poll(self, param): # noqa: C901
+    def _on_poll(self, param):  # noqa: C901
 
         self.save_progress("In action handler for: {0}".format(self.get_action_identifier()))
         action_result = self.add_action_result(ActionResult(dict(param)))


### PR DESCRIPTION
The CrowdStrike app was originally assigning the last element in the array of artifacts to have the value 'run_automation' = True. This created an issue where containers were not being ran in the instance that CrowdStrike sent duplicate artifacts. Because the last artifact is the only index containing the run_automation value of True, it can be removed if the last artifact is also a duplicate of an artifact before it in the array. To fix this the CrowdStrike app now assigns 'run_automation' = True to the first available artifact.