### PR TITLE
PAPP-18172 PAPP-19045 - fixed a bug with on_poll

### DIFF
--- a/Apps/phcrowdstrikeoauth/crowdstrikeoauthapi.json
+++ b/Apps/phcrowdstrikeoauth/crowdstrikeoauthapi.json
@@ -15,7 +15,7 @@
         }
      ],
     "license": "Copyright (c) 2019-2021 Splunk Inc.",
-    "app_version": "3.2.1",
+    "app_version": "3.2.0",
     "latest_tested_versions": [
         "Cloud, API api.crowdstrike.com, July 19 2021, API version: v1, v2"
     ],

--- a/Apps/phcrowdstrikeoauth/crowdstrikeoauthapi.json
+++ b/Apps/phcrowdstrikeoauth/crowdstrikeoauthapi.json
@@ -15,7 +15,7 @@
         }
      ],
     "license": "Copyright (c) 2019-2021 Splunk Inc.",
-    "app_version": "3.2.0",
+    "app_version": "3.2.1",
     "latest_tested_versions": [
         "Cloud, API api.crowdstrike.com, July 19 2021, API version: v1, v2"
     ],


### PR DESCRIPTION
where streamed data was assumed to be complete each chunk, but in reality potentially came in multiple, separate chunks


Please ensure your pull request (PR) adheres to the following guidelines:

- Please refer to our contributing documentation for any questions on submitting a pull request, link: [Contribution Guide](https://github.com/phantomcyber/phantom-apps/blob/master/.github/CONTRIBUTING.md)

## Pull Request Checklist

#### Please check if your PR fulfills the following requirements:
- [x] Testing of all the changes has been performed (for bug fixes / features)
- [ ] The readme.html has been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Use the following format for the PR description: `<App Name>: <PR Type> - <PR Description>`
- [ ] Provide release notes as part of the PR submission which describe high level points about the changes for the upcoming GA release.
- [x] Verify all checks are passing.
- [x] Do NOT use the `next` branch of the forked repo. Create separate feature branch for raising the PR.
- [x] Do NOT submit updates to dependencies unless it fixes an issue.
- [x] Limit your pull request to one application and submit multiple pull requests if necessary.
## Pull Request Type

#### Please check the type of change your PR introduces:
- [ ] New App
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation
- [ ] Other (please describe): 

## Release Notes (REQUIRED)
- Fixed an issue with on_poll (ingestion) where streamed data was assumed to be complete per-chunk, but the reality was that event data could potentially be streamed across multiple chunks. The previous behavior caused an error and would result in no container/event being created from the event data.

## What is the current behavior? (OPTIONAL)
- See above. The requests module stream object possesses a method called iter_content() which would stream a block of data (based on chunk_size parameter)

## What is the new behavior? (OPTIONAL)
- We now use the iter_lines method which will block on the stream until a newline character is encountered or a timeout is triggered. This will prevent incomplete data from being streamed as the boundary of events is a newline character.


## Other information (OPTIONAL)
- N/A

## Pay close attention to (OPTIONAL)
- This affects on_poll only. There were several false positives in the automated testing, but I could reliably reproduce it with the lab data using manual ingestion (Poll Now)

## Screenshots (if relevant)

---
Thanks for contributing!
