### PR TITLE
Removing 'Splunk Confidential: XYZ' comments that are no longer needed

### DIFF
--- a/Apps/phawscloudtrail/readme.html
+++ b/Apps/phawscloudtrail/readme.html
@@ -1,8 +1,5 @@
 <!-- File: readme.html
   Copyright (c) 2018-2021 Splunk Inc.
-
-  SPLUNK CONFIDENTIAL - Use or disclosure of this material in whole or in part
-  without a valid written license from Splunk Inc. is PROHIBITED.
 -->
 <html>
 <body>

--- a/Apps/phawscloudtrail/readme.md
+++ b/Apps/phawscloudtrail/readme.md
@@ -1,9 +1,5 @@
 [comment]: # " File: readme.md"
 [comment]: # "  Copyright (c) 2018-2021 Splunk Inc."
-[comment]: # ""
-[comment]: # "  SPLUNK CONFIDENTIAL - Use or disclosure of this material in whole or in part"
-[comment]: # "  without a valid written license from Splunk Inc. is PROHIBITED."
-[comment]: # ""
 ## Asset Configuration
 
 There are two ways to configure an AWS CloudTrail asset. The first is to configure the

--- a/Apps/phawswafv2/readme.html
+++ b/Apps/phawswafv2/readme.html
@@ -1,8 +1,5 @@
 <!-- File: readme.html
   Copyright (c) 2018-2021 Splunk Inc.
-
-  SPLUNK CONFIDENTIAL - Use or disclosure of this material in whole or in part
-  without a valid written license from Splunk Inc. is PROHIBITED.
 -->
 <html>
 <body>

--- a/Apps/phawswafv2/readme.md
+++ b/Apps/phawswafv2/readme.md
@@ -1,9 +1,5 @@
 [comment]: # " File: readme.md"
 [comment]: # "  Copyright (c) 2018-2021 Splunk Inc."
-[comment]: # ""
-[comment]: # "  SPLUNK CONFIDENTIAL - Use or disclosure of this material in whole or in part"
-[comment]: # "  without a valid written license from Splunk Inc. is PROHIBITED."
-[comment]: # ""
 ## Asset Configuration
 
 There are two ways to configure an AWS WAF asset. The first is to configure the **access_key** ,

--- a/Apps/phrequesttracker/__init__.py
+++ b/Apps/phrequesttracker/__init__.py
@@ -1,5 +1,3 @@
 # File: __init__.py
 # Copyright (c) 2021 Splunk Inc.
 #
-# SPLUNK CONFIDENTIAL - Use or disclosure of this material in whole or in part
-# without a valid written license from Splunk Inc. is PROHIBITED.

--- a/Apps/phrequesttracker/requesttracker_connector.py
+++ b/Apps/phrequesttracker/requesttracker_connector.py
@@ -1,8 +1,5 @@
 # File: rt_connector.py
 # Copyright (c) 2021 Splunk Inc.
-#
-# SPLUNK CONFIDENTIAL - Use or disclosure of this material in whole or in part
-# without a valid written license from Splunk Inc. is PROHIBITED.
 
 # Phantom imports
 import phantom.app as phantom

--- a/Apps/phrequesttracker/requesttracker_consts.py
+++ b/Apps/phrequesttracker/requesttracker_consts.py
@@ -1,8 +1,5 @@
 # File: rt_consts.py
 # Copyright (c) 2021 Splunk Inc.
-#
-# SPLUNK CONFIDENTIAL - Use or disclosure of this material in whole or in part
-# without a valid written license from Splunk Inc. is PROHIBITED.
 
 
 RT_JSON_DEVICE_URL = "device_url"

--- a/Apps/phsplunkoncall/__init__.py
+++ b/Apps/phsplunkoncall/__init__.py
@@ -1,7 +1,5 @@
 # File: __init__.py
 #
-# SPLUNK CONFIDENTIAL - Use or disclosure of this material in whole or in part
-# without a valid written license from Splunk Inc. is PROHIBITED.# File: __init__.py
 # Copyright (c) 2018-2021 Splunk Inc.
 #
 # Licensed under Apache 2.0 (https://www.apache.org/licenses/LICENSE-2.0.txt)

--- a/Apps/phsplunkoncall/display_list_routing.html
+++ b/Apps/phsplunkoncall/display_list_routing.html
@@ -13,10 +13,6 @@
   Copyright (c) 2018-2021 Splunk Inc.
 
 Licensed under Apache 2.0 (https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-
-SPLUNK CONFIDENTIAL - Use or disclosure of this material in whole or in part
-without a valid written license from Splunk Inc. is PROHIBITED.
 -->
 
 <style>


### PR DESCRIPTION
### Notes
- Removing boilerplate comments of the type `Splunk Confidential` that existed before the code was open-sourced